### PR TITLE
Prevent timeout on single node configuration

### DIFF
--- a/src/main/java/io/vlingo/xoom/cluster/model/node/LocalLiveNodeActor.java
+++ b/src/main/java/io/vlingo/xoom/cluster/model/node/LocalLiveNodeActor.java
@@ -45,7 +45,6 @@ public class LocalLiveNodeActor extends Actor
   private final List<NodeSynchronizer> nodeSynchronizers;
   private final OperationalOutboundStream outbound;
   private boolean quorumAchieved;
-  private final LocalLiveNode selfLocalLiveNode;
   private final ClusterSnapshot snapshot;
   private final Registry registry;
 
@@ -62,7 +61,6 @@ public class LocalLiveNodeActor extends Actor
     this.outbound = outbound;
     this.configuration = configuration;
     this.nodeSynchronizers = new ArrayList<>();
-    this.selfLocalLiveNode = selfAs(LocalLiveNode.class);
     this.checkHealth = new CheckHealth(node.id());
     this.cancellable = scheduleHealthCheck();
 
@@ -243,9 +241,8 @@ public class LocalLiveNodeActor extends Actor
 
   @Override
   public void intervalSignal(final Scheduled<Object> scheduled, final Object data) {
+    handle(checkHealth); // refresh lastHealthIndication; prevent timeout for single node scenario
     registry.cleanTimedOutNodes();
-
-    selfLocalLiveNode.handle(checkHealth);
   }
 
 


### PR DESCRIPTION
In rare situations, local node in a single node cluster configuration is cleaned from registry due to timeout and it doesn't recover from this state.
`lastHealthIndication` of the local node is updated asynchronously and is scheduled too late.
`cleanTimedOutNodes()` method finds an outdated version `lastHealthIndication` and times out the local node.
This pull request is fixing above issue.